### PR TITLE
Fixed link typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ DATABASE_NAME = ENV_CONSUL.get_str('/databases/default/name')
 - Typed retrieval of environment variables
 - EnvConsol object implements a simple ReadOnly/Immutable dict
 - Implemented using supported Python's Consul `consulate`
-  - [https://github.com/gmr/consulate](https://github.com/gmr/consulate])
+  - https://github.com/gmr/consulate
 
 
 ## Install


### PR DESCRIPTION
There was an additional `]` character in the link.  Figured I'd just remove the markdown link syntax and let github just link it automatically.
