### PR TITLE
fixes default error when using lists or tuples

### DIFF
--- a/envconsul/envconsul.py
+++ b/envconsul/envconsul.py
@@ -43,10 +43,12 @@ class EnvConsul(collections.Mapping):
     def get_str(self, key, default=None):
         return str(self._d.get(key, default))
 
-    def get_tuple(self, key, default=[]):
+    def get_tuple(self, key, default=None):
+        default = default or tuple()
         return tuple(self.get_list(key, default))
 
-    def get_list(self, key, default=[]):
+    def get_list(self, key, default=None):
+        default = default or []
         data = self._d.get(key, default)
         if data and LIST_DELIM in data:
             data = data.split(LIST_DELIM)


### PR DESCRIPTION
You do not want to pass [] as a default value in the function signature. It is initialized at the moment the function is created not per run. For example:

``` python
def value(default=[]):  # [] is initialized when the interpreter creates the function, it is the same [] each run of the function
    return default

v1 = value()
v1  # []

v1.append("python")
v1  # ['python']

v2 = value()
v2  # ['python'] <- check me out, I have an unexpected value!
```
