### PR TITLE
Correct curl command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ ENV_CONSUL = envconsul.EnvConsul(
 ##### Bool type
 
 ```shell
-curl -x PUT -d 'True' http://localhost:8500/v1/kv/web00.django.test/debug
+curl -X PUT -d 'True' http://localhost:8500/v1/kv/web00.django.test/debug
 ```
 
 ```python


### PR DESCRIPTION
Need to use capital X for proper curl in the README file. 